### PR TITLE
add option to refer to images by their "name" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Please note the following:
 **Supported Configuration Attributes**
 
 The following attributes are available to further configure the provider:
-- `provider.image` - A string representing the image to use when creating a new droplet. It defaults to `ubuntu-14-04-x64`. List available images with the `digitalocean-list images` command.
+- `provider.image` - A string referring to the image slug to use when creating a new droplet. It defaults to `ubuntu-14-04-x64`. List available images with the `digitalocean-list images` command.
+- `provider.image_name` - Same as above, but refers to the actual image name rather than the slug. Use this to create a droplet from one of your private snapshots.
 - `provider.ipv6` - A boolean flag indicating whether to enable IPv6
 - `provider.region` - A string representing the region to create the new droplet in. It defaults to `nyc2`. List available regions with the `digitalocean-list regions` command.
 - `provider.size` - A string representing the size to use when creating a

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -17,9 +17,13 @@ module VagrantPlugins
         def call(env)
           ssh_key_id = [env[:ssh_key_id]]
 
+          search = @machine.provider_config.image_name.nil? ?
+            {:slug => @machine.provider_config.image} :
+            {:name => @machine.provider_config.image_name}
+
           image_id = @client
             .request('/v2/images')
-            .find_id(:images, :slug => @machine.provider_config.image)
+            .find_id(:images, search)
 
           # submit new droplet request
           result = @client.post('/v2/droplets', {

--- a/lib/vagrant-digitalocean/actions/rebuild.rb
+++ b/lib/vagrant-digitalocean/actions/rebuild.rb
@@ -15,10 +15,14 @@ module VagrantPlugins
         end
 
         def call(env)
+          search = @machine.provider_config.image_name.nil? ?
+            {:slug => @machine.provider_config.image} :
+            {:name => @machine.provider_config.image_name}
+
           # look up image id
           image_id = @client
             .request('/v2/images')
-            .find_id(:images, :slug => @machine.provider_config.image)
+            .find_id(:images, search)
 
           # submit rebuild request
           result = @client.post("/v2/droplets/#{@machine.id}/actions", {

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -3,6 +3,7 @@ module VagrantPlugins
     class Config < Vagrant.plugin('2', :config)
       attr_accessor :token
       attr_accessor :image
+      attr_accessor :image_name
       attr_accessor :region
       attr_accessor :size
       attr_accessor :private_networking
@@ -18,6 +19,7 @@ module VagrantPlugins
       def initialize
         @token              = UNSET_VALUE
         @image              = UNSET_VALUE
+        @image_name         = UNSET_VALUE
         @region             = UNSET_VALUE
         @size               = UNSET_VALUE
         @private_networking = UNSET_VALUE
@@ -32,6 +34,7 @@ module VagrantPlugins
       def finalize!
         @token              = ENV['DO_TOKEN'] if @token == UNSET_VALUE
         @image              = 'ubuntu-14-04-x64' if @image == UNSET_VALUE
+        @image_name         = nil if @image_name == UNSET_VALUE
         @region             = 'nyc2' if @region == UNSET_VALUE
         @size               = '512mb' if @size == UNSET_VALUE
         @private_networking = false if @private_networking == UNSET_VALUE


### PR DESCRIPTION
Currently it's only possible to refer to images using their slug.

This adds the possibility to refer to images using the name field,
while preserving backwards compatibility.
